### PR TITLE
Use int() for timestamp

### DIFF
--- a/ceph_exporter.py
+++ b/ceph_exporter.py
@@ -48,7 +48,7 @@ class Sample(object):
             result += '{{{:s}}}'.format(','.join(map(lambda l: l.fmt(), self.labels)))
         result += ' {}'.format(self.value)
         if self.timestamp is not None:
-            result += ' {:d}'.format(round(self.timestamp.float_timestamp * 1000))
+            result += ' {:d}'.format(int(round(self.timestamp.float_timestamp * 1000)))
         return result
 
     def isExpired(self, now):


### PR DESCRIPTION
Use int() for timestamp. Example after change.

```
ceph_pool_bytes_second{fsid="fab64e84-7266-4c40-94ac-3eec00d9db99",pool="0",name="rbd",type="read"} 0 1470987666506
```

@jcollie 
